### PR TITLE
Initialize task queue skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,19 @@
-# Calculator (RPN, Functional Style)
+# Task Queue System
 
-This is a simple Reverse Polish Notation (RPN) calculator implemented in Go using a functional programming paradigm.
+This repository contains an experimental implementation of a task queue system written in Go. It demonstrates a REST API using Gin, PostgreSQL access via pgx, and a simple integration with AWS SQS for message queuing.
 
-Features:
-- Pure functions for token processing and evaluation
-- Higher-order `FoldTokens` function for reducing tokens over a stack
-- Interactive REPL or single-expression evaluation via command-line arguments
+The project layout follows a typical Go application structure with code organized under the `internal/` directory. The `cmd/server` entrypoint starts the HTTP server and exposes minimal endpoints for enqueuing tasks and health checks.
 
-Requirements:
-- Go 1.20 or later
+This is a work in progress and only a subset of the planned features are implemented.
 
-Usage:
-1. Evaluate a single expression:
-   ```sh
-   go run main.go "3 4 +"
-   # Output: 7
-   ```
-   Note: wrap expressions containing `*` or other shell-special characters in quotes.
+## Quick start
 
-2. Start the interactive REPL:
-   ```sh
-   go run main.go
-   # RPN Calculator
-   # Enter expression in Reverse Polish Notation, or 'exit' to quit.
-   > 3 4 + 2 *
-   Result: 14
-   > exit
-   ```
-
-Building:
 ```sh
-go build -o calculator
-./calculator "5 1 2 + 4 * + 3 -"
-# Output: 14
+PORT=8080 DATABASE_URL=postgres://user:pass@localhost:5432/db \
+AWS_SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account/queue \
+go run ./cmd/server
 ```
+
+## Legacy Calculator
+
+The repository previously held a simple Reverse Polish Notation calculator which remains in `main.go` for reference.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"taskqueue/internal/config"
+	"taskqueue/internal/database"
+	"taskqueue/internal/queue"
+	"taskqueue/pkg/logger"
+)
+
+func main() {
+	cfg := config.Load()
+
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.Default()
+
+	ctx := context.Background()
+
+	db, err := database.Connect(ctx, cfg.DatabaseURL)
+	if err != nil {
+		logger.Error("db connect:", err)
+		return
+	}
+	defer db.Close()
+
+	q, err := queue.New(ctx, cfg.AWSRegion, cfg.SQSQueueURL)
+	if err != nil {
+		logger.Error("sqs:", err)
+		return
+	}
+
+	r.GET("/healthz", func(c *gin.Context) {
+		if err := db.Ping(ctx); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "db unreachable"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	r.POST("/api/tasks", func(c *gin.Context) {
+		// simplified task enqueue example
+		var req struct {
+			Payload string `json:"payload"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+		id, err := q.Enqueue(ctx, req.Payload)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enqueue"})
+			return
+		}
+		c.JSON(http.StatusAccepted, gin.H{"message_id": id})
+	})
+
+	logger.Info("starting server on", cfg.Port)
+	r.Run(":" + cfg.Port)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,11 @@
-module calculator
+module taskqueue
 
 go 1.20
+
+require (
+    github.com/gin-gonic/gin v1.10.1
+    github.com/golang-jwt/jwt/v5 v5.2.2
+    github.com/aws/aws-sdk-go-v2/config v1.29.15
+    github.com/aws/aws-sdk-go-v2/service/sqs v1.38.6
+    github.com/jackc/pgx/v5 v5.7.5
+)

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// GenerateToken creates a signed JWT for the given user ID.
+func GenerateToken(secret string, userID int64) (string, error) {
+	claims := jwt.MapClaims{
+		"sub": userID,
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"log"
+	"os"
+)
+
+// Config holds application configuration loaded from environment variables.
+// For brevity only a subset of the variables is included.
+type Config struct {
+	Port           string
+	DatabaseURL    string
+	JWTSecret      string
+	GoogleClientID string
+	GoogleSecret   string
+	GoogleRedirect string
+	AWSRegion      string
+	SQSQueueURL    string
+}
+
+// Load reads environment variables into Config.
+func Load() *Config {
+	cfg := &Config{
+		Port:           getEnv("PORT", "8080"),
+		DatabaseURL:    getEnv("DATABASE_URL", "postgres://user:pass@localhost:5432/db"),
+		JWTSecret:      os.Getenv("JWT_SECRET"),
+		GoogleClientID: os.Getenv("GOOGLE_CLIENT_ID"),
+		GoogleSecret:   os.Getenv("GOOGLE_CLIENT_SECRET"),
+		GoogleRedirect: os.Getenv("GOOGLE_REDIRECT_URL"),
+		AWSRegion:      getEnv("AWS_REGION", "us-east-1"),
+		SQSQueueURL:    os.Getenv("AWS_SQS_QUEUE_URL"),
+	}
+	if cfg.JWTSecret == "" {
+		log.Println("warning: JWT_SECRET not set")
+	}
+	return cfg
+}
+
+func getEnv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -1,0 +1,11 @@
+package database
+
+import (
+	"context"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Connect creates a new pgx connection pool.
+func Connect(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
+	return pgxpool.New(ctx, dsn)
+}

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -1,0 +1,33 @@
+package models
+
+import "time"
+
+// User represents an authenticated user.
+type User struct {
+	ID        int64     `db:"id"`
+	GoogleID  string    `db:"google_id"`
+	Email     string    `db:"email"`
+	Name      string    `db:"name"`
+	Picture   string    `db:"picture"`
+	CreatedAt time.Time `db:"created_at"`
+	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// Task represents a queued task.
+type Task struct {
+	ID          int64     `db:"id"`
+	UserID      int64     `db:"user_id"`
+	Name        string    `db:"name"`
+	Type        string    `db:"type"`
+	Priority    string    `db:"priority"`
+	Status      string    `db:"status"`
+	Payload     []byte    `db:"payload"`
+	Result      []byte    `db:"result"`
+	Error       string    `db:"error_message"`
+	MessageID   string    `db:"message_id"`
+	WorkerID    string    `db:"worker_id"`
+	StartedAt   time.Time `db:"started_at"`
+	CompletedAt time.Time `db:"completed_at"`
+	CreatedAt   time.Time `db:"created_at"`
+	UpdatedAt   time.Time `db:"updated_at"`
+}

--- a/internal/queue/sqs.go
+++ b/internal/queue/sqs.go
@@ -1,0 +1,39 @@
+package queue
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
+)
+
+// Client wraps AWS SQS.
+type Client struct {
+	svc      *sqs.Client
+	queueURL string
+}
+
+// New creates a new SQS client using default credentials.
+func New(ctx context.Context, region, queueURL string) (*Client, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		svc:      sqs.NewFromConfig(cfg),
+		queueURL: queueURL,
+	}, nil
+}
+
+// Enqueue sends a message to SQS.
+func (c *Client) Enqueue(ctx context.Context, body string) (string, error) {
+	out, err := c.svc.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:    aws.String(c.queueURL),
+		MessageBody: aws.String(body),
+	})
+	if err != nil {
+		return "", err
+	}
+	return aws.ToString(out.MessageId), nil
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,0 +1,15 @@
+package logger
+
+import (
+	"log"
+)
+
+// Info prints an informational message.
+func Info(args ...interface{}) {
+	log.Println(args...)
+}
+
+// Error prints an error message.
+func Error(args ...interface{}) {
+	log.Println(args...)
+}


### PR DESCRIPTION
## Summary
- restructure repository for new task queue system
- add configuration loader and basic AWS SQS client
- implement minimal HTTP server using Gin
- include sample models and simple logger
- update README with brief instructions

## Testing
- `go vet ./...` *(fails: missing modules)*
- `go build ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_68440b9f8d5483238e91f64c3c1611e8