### PR TITLE
Add API versioning and queue health check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains an experimental implementation of a task queue system written in Go. It demonstrates a REST API using Gin, PostgreSQL access via pgx, and a simple integration with AWS SQS for message queuing.
 
-The project layout follows a typical Go application structure with code organized under the `internal/` directory. The `cmd/server` entrypoint starts the HTTP server and exposes minimal endpoints for enqueuing tasks and health checks.
+The project layout follows a typical Go application structure with code organized under the `internal/` directory. The `cmd/server` entrypoint starts the HTTP server and exposes endpoints for creating and retrieving tasks along with a health check. The health endpoint verifies database and SQS connectivity.
 
 This is a work in progress and only a subset of the planned features are implemented.
 
@@ -13,6 +13,14 @@ PORT=8080 DATABASE_URL=postgres://user:pass@localhost:5432/db \
 AWS_SQS_QUEUE_URL=https://sqs.region.amazonaws.com/account/queue \
 go run ./cmd/server
 ```
+
+The server exposes the following endpoints (API version 1):
+
+- `POST /api/v1/tasks` – enqueue a new task (parameters: `name`, `payload`)
+- `GET /api/v1/tasks` – list all tasks
+- `GET /api/v1/tasks/:id` – retrieve a single task by ID
+
+Database tables are created automatically on startup.
 
 ## Legacy Calculator
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -3,17 +3,21 @@ package main
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 
 	"taskqueue/internal/config"
 	"taskqueue/internal/database"
+	"taskqueue/internal/models"
 	"taskqueue/internal/queue"
 	"taskqueue/pkg/logger"
 )
 
 func main() {
 	cfg := config.Load()
+
+	logger.Init(cfg.LogLevel)
 
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
@@ -27,6 +31,11 @@ func main() {
 	}
 	defer db.Close()
 
+	if err := database.Migrate(ctx, db); err != nil {
+		logger.Error("migrate:", err)
+		return
+	}
+
 	q, err := queue.New(ctx, cfg.AWSRegion, cfg.SQSQueueURL)
 	if err != nil {
 		logger.Error("sqs:", err)
@@ -38,24 +47,65 @@ func main() {
 			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "db unreachable"})
 			return
 		}
+		if err := q.HealthCheck(ctx); err != nil {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"status": "queue unreachable"})
+			return
+		}
 		c.JSON(http.StatusOK, gin.H{"status": "ok"})
 	})
 
-	r.POST("/api/tasks", func(c *gin.Context) {
-		// simplified task enqueue example
+	api := r.Group("/api/v1")
+
+	api.POST("/tasks", func(c *gin.Context) {
 		var req struct {
+			Name    string `json:"name"`
 			Payload string `json:"payload"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 			return
 		}
-		id, err := q.Enqueue(ctx, req.Payload)
+		msgID, err := q.Enqueue(ctx, req.Payload)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to enqueue"})
 			return
 		}
-		c.JSON(http.StatusAccepted, gin.H{"message_id": id})
+		task := &models.Task{ // simplified model
+			Name:      req.Name,
+			Payload:   []byte(req.Payload),
+			Status:    "queued",
+			MessageID: msgID,
+		}
+		id, err := models.InsertTask(ctx, db, task)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "db insert failed"})
+			return
+		}
+		c.JSON(http.StatusAccepted, gin.H{"id": id, "message_id": msgID})
+	})
+
+	api.GET("/tasks", func(c *gin.Context) {
+		tasks, err := models.ListTasks(ctx, db)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "db error"})
+			return
+		}
+		c.JSON(http.StatusOK, tasks)
+	})
+
+	api.GET("/tasks/:id", func(c *gin.Context) {
+		idParam := c.Param("id")
+		tid, err := strconv.ParseInt(idParam, 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+			return
+		}
+		task, err := models.GetTask(ctx, db, tid)
+		if err != nil {
+			c.JSON(http.StatusNotFound, gin.H{"error": "task not found"})
+			return
+		}
+		c.JSON(http.StatusOK, task)
 	})
 
 	logger.Info("starting server on", cfg.Port)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
     github.com/gin-gonic/gin v1.10.1
     github.com/golang-jwt/jwt/v5 v5.2.2
+    github.com/sirupsen/logrus v1.9.3
     github.com/aws/aws-sdk-go-v2/config v1.29.15
     github.com/aws/aws-sdk-go-v2/service/sqs v1.38.6
     github.com/jackc/pgx/v5 v5.7.5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	GoogleRedirect string
 	AWSRegion      string
 	SQSQueueURL    string
+	LogLevel       string
 }
 
 // Load reads environment variables into Config.
@@ -29,6 +30,7 @@ func Load() *Config {
 		GoogleRedirect: os.Getenv("GOOGLE_REDIRECT_URL"),
 		AWSRegion:      getEnv("AWS_REGION", "us-east-1"),
 		SQSQueueURL:    os.Getenv("AWS_SQS_QUEUE_URL"),
+		LogLevel:       getEnv("LOG_LEVEL", "info"),
 	}
 	if cfg.JWTSecret == "" {
 		log.Println("warning: JWT_SECRET not set")

--- a/internal/database/migrate.go
+++ b/internal/database/migrate.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Migrate creates required database tables if they do not exist.
+func Migrate(ctx context.Context, db *pgxpool.Pool) error {
+	_, err := db.Exec(ctx, `
+CREATE TABLE IF NOT EXISTS tasks (
+    id BIGSERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    message_id TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+`)
+	return err
+}

--- a/internal/models/tasks.go
+++ b/internal/models/tasks.go
@@ -1,0 +1,56 @@
+package models
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// InsertTask stores a new task in the database and returns its ID.
+func InsertTask(ctx context.Context, db *pgxpool.Pool, t *Task) (int64, error) {
+	row := db.QueryRow(ctx, `
+        INSERT INTO tasks (name, payload, status, message_id)
+        VALUES ($1, $2, $3, $4)
+        RETURNING id
+    `, t.Name, t.Payload, t.Status, t.MessageID)
+	var id int64
+	if err := row.Scan(&id); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+// ListTasks returns all tasks in the database ordered by creation time descending.
+func ListTasks(ctx context.Context, db *pgxpool.Pool) ([]Task, error) {
+	rows, err := db.Query(ctx, `
+        SELECT id, name, payload, status, message_id, created_at, updated_at
+        FROM tasks ORDER BY created_at DESC
+    `)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var tasks []Task
+	for rows.Next() {
+		var t Task
+		if err := rows.Scan(&t.ID, &t.Name, &t.Payload, &t.Status, &t.MessageID, &t.CreatedAt, &t.UpdatedAt); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+// GetTask retrieves a task by ID.
+func GetTask(ctx context.Context, db *pgxpool.Pool, id int64) (*Task, error) {
+	row := db.QueryRow(ctx, `
+        SELECT id, name, payload, status, message_id, created_at, updated_at
+        FROM tasks WHERE id=$1
+    `, id)
+	var t Task
+	if err := row.Scan(&t.ID, &t.Name, &t.Payload, &t.Status, &t.MessageID, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return nil, err
+	}
+	return &t, nil
+}

--- a/internal/queue/sqs.go
+++ b/internal/queue/sqs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
+	"github.com/aws/aws-sdk-go-v2/service/sqs/types"
 )
 
 // Client wraps AWS SQS.
@@ -36,4 +37,13 @@ func (c *Client) Enqueue(ctx context.Context, body string) (string, error) {
 		return "", err
 	}
 	return aws.ToString(out.MessageId), nil
+}
+
+// HealthCheck verifies the queue is reachable.
+func (c *Client) HealthCheck(ctx context.Context) error {
+	_, err := c.svc.GetQueueAttributes(ctx, &sqs.GetQueueAttributesInput{
+		QueueUrl:       aws.String(c.queueURL),
+		AttributeNames: []types.QueueAttributeName{types.QueueAttributeNameQueueArn},
+	})
+	return err
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		expr string
+		want float64
+	}{
+		{"3 4 +", 7},
+		{"10 2 /", 5},
+		{"2 3 4 * +", 14},
+	}
+	for _, tt := range tests {
+		got, err := Evaluate(strings.Fields(tt.expr))
+		if err != nil {
+			t.Fatalf("%s: %v", tt.expr, err)
+		}
+		if got != tt.want {
+			t.Errorf("%s: want %v got %v", tt.expr, tt.want, got)
+		}
+	}
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -1,15 +1,24 @@
 package logger
 
 import (
-	"log"
+	"github.com/sirupsen/logrus"
 )
+
+// Init sets the global log level.
+func Init(level string) {
+	l, err := logrus.ParseLevel(level)
+	if err != nil {
+		l = logrus.InfoLevel
+	}
+	logrus.SetLevel(l)
+}
 
 // Info prints an informational message.
 func Info(args ...interface{}) {
-	log.Println(args...)
+	logrus.Info(args...)
 }
 
 // Error prints an error message.
 func Error(args ...interface{}) {
-	log.Println(args...)
+	logrus.Error(args...)
 }


### PR DESCRIPTION
## Summary
- add log level config and structured logging with logrus
- support versioned API routes under `/api/v1`
- expand health check to verify SQS connectivity
- expose log level in configuration
- add `HealthCheck` method to SQS client
- update README with new endpoints and health check info
- basic tests for the RPN evaluator

## Testing
- `go vet ./...` *(fails: missing go.sum entries)*
- `go test ./...` *(fails: missing go.sum entries)*

------
https://chatgpt.com/codex/tasks/task_e_68440dded1a08323a129dba410e07ec5